### PR TITLE
Develop

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,11 +2,9 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/RetussJava9.iml" filepath="$PROJECT_DIR$/.idea/RetussJava9.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/retuss.iml" filepath="$PROJECT_DIR$/.idea/modules/retuss.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/retuss_main.iml" filepath="$PROJECT_DIR$/.idea/modules/retuss_main.iml" group="retuss" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/retuss_test.iml" filepath="$PROJECT_DIR$/.idea/modules/retuss_test.iml" group="retuss" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/window.iml" filepath="$PROJECT_DIR$/.idea/modules/window.iml" />
     </modules>
   </component>
 </project>

--- a/src/main/java/io/github/morichan/retuss/language/cpp/Class.java
+++ b/src/main/java/io/github/morichan/retuss/language/cpp/Class.java
@@ -188,6 +188,17 @@ public class Class {
     private String manufacture() {
         StringBuilder sb = new StringBuilder();
         boolean flagProtected =false;
+boolean flagString=false;
+        for(MemberVariable memberVariable : memberVariables){
+            if(memberVariable.getFlagString()== true){
+               flagString= true;
+            }
+        }
+if(flagString == true){
+            sb.append("#include <string>");
+    sb.append(" \n");
+        }
+
         sb.append("class ");
         sb.append(name);
 

--- a/src/main/java/io/github/morichan/retuss/language/cpp/MemberVariable.java
+++ b/src/main/java/io/github/morichan/retuss/language/cpp/MemberVariable.java
@@ -107,6 +107,9 @@ public class MemberVariable {
      */
     public void setType(Type type) {
         if (type == null) throw new IllegalArgumentException();
+        if(type.getTypeName().equals("String")){
+            type.setTypesName("std::string");
+        }
         this.type = type;
     }
 

--- a/src/main/java/io/github/morichan/retuss/language/cpp/MemberVariable.java
+++ b/src/main/java/io/github/morichan/retuss/language/cpp/MemberVariable.java
@@ -9,6 +9,7 @@ public class MemberVariable {
     private Type type;
     private String name;
     private Value value;
+    private boolean flagString=false;
 
     /**
      * <p> デフォルトコンストラクタ </p>
@@ -109,6 +110,7 @@ public class MemberVariable {
         if (type == null) throw new IllegalArgumentException();
         if(type.getTypeName().equals("String")){
             type.setTypesName("std::string");
+            flagString=true;
         }
         this.type = type;
     }
@@ -151,6 +153,9 @@ public class MemberVariable {
     public Value getValue() {
         return value;
     }
+
+
+    public boolean getFlagString(){return  flagString;}
 
     @Override
     public String toString() {

--- a/src/main/java/io/github/morichan/retuss/language/cpp/Type.java
+++ b/src/main/java/io/github/morichan/retuss/language/cpp/Type.java
@@ -48,6 +48,18 @@ public class Type {
     }
 
     /**
+     * <p> 型名を取得します </p>
+     */
+public String getTypeName(){return types.get(types.size()-1);}
+
+
+    /**
+     * <p> 型名を変更します </p>
+     */
+public void setTypesName(String typesName){types.set(types.size()-1,typesName);}
+
+
+    /**
      * <p> 配列の次元数を設定します </p>
      *
      * @param count 配列の次元数
@@ -79,6 +91,11 @@ public class Type {
         if (types.size() <= 0) {
             sb.append("int");
         } else if (dataTypes.size() <= 0) {
+//            for(int i=0;i<types.size();i++) {
+//                if (types.get(i) == "String") {
+//                    types.set(i,"std::string");
+//                }
+//            }
             sb.append(String.join(".", types));
         } else {
             List<String> data = new ArrayList<>();

--- a/src/main/java/io/github/morichan/retuss/listener/CppEvalListener.java
+++ b/src/main/java/io/github/morichan/retuss/listener/CppEvalListener.java
@@ -58,7 +58,11 @@ public class CppEvalListener extends CPP14BaseListener {
 
                     for (int i = 0; i < ctx.getChildCount(); i++) {
                         if (ctx.getChild(i) instanceof CPP14Parser.DeclspecifierseqContext) {
-                            memberVariable.setType(new Type(ctx.getChild(i).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getText()));
+                            if(ctx.getChild(i).getChild(0).getChild(0).getChild(0).getChild(0).getChildCount() > 1){     //stringの分岐に対応。
+                                memberVariable.setType(new Type(ctx.getChild(i).getChild(0).getChild(0).getChild(0).getChild(0).getChild(1).getChild(0).getChild(0).getText()));
+                            }else {
+                                memberVariable.setType(new Type(ctx.getChild(i).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getText()));
+                            }
                         }
                         if (ctx.getChild(i) instanceof CPP14Parser.MemberdeclaratorlistContext) {
                             memberVariable.setName(ctx.getChild(i).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getText());

--- a/src/main/java/io/github/morichan/retuss/listener/CppEvalListener.java
+++ b/src/main/java/io/github/morichan/retuss/listener/CppEvalListener.java
@@ -21,6 +21,7 @@ public class CppEvalListener extends CPP14BaseListener {
     private AccessSpecifier accessSpecifier=null;
     boolean isAlreadySearchedAccessSpecifier = false;
     boolean functiondefinitionFlag=false;
+    boolean memberdeclarationFlag=false;
 
     @Override
     public void enterTranslationunit(CPP14Parser.TranslationunitContext ctx) {
@@ -35,7 +36,6 @@ public class CppEvalListener extends CPP14BaseListener {
     public void enterMemberspecification(CPP14Parser.MemberspecificationContext ctx) {
      //   accessSpecifier = null;
 
-
         for (int i = 0; i < ctx.getChildCount(); i++) {
             if (ctx.getChild(i) instanceof CPP14Parser.AccessspecifierContext) {
                 accessSpecifier=accessSpecifier.choose(ctx.getChild(i).getChild(0).getText());
@@ -45,29 +45,55 @@ public class CppEvalListener extends CPP14BaseListener {
 //        cpp.addClass(cppClass);
     }
 
-    @Override public void enterMemberdeclaration(CPP14Parser.MemberdeclarationContext ctx) {
-        MemberVariable memberVariable = new MemberVariable();
+           @Override public void enterMemberdeclaration(CPP14Parser.MemberdeclarationContext ctx) {
+            // MemberVariable memberVariable = new MemberVariable();
+            memberdeclarationFlag=true;
+            if((ctx.getChild(0) instanceof CPP14Parser.FunctiondefinitionContext) == false) {
+                if (ctx.getChild(1).getChild(0).getChild(0).getChild(0).getChild(0).getChildCount() == 1) {     //メンバ変数の時
+                    MemberVariable memberVariable = new MemberVariable();
+                    if (accessSpecifier != null) {
+                        memberVariable.setAccessSpecifier(accessSpecifier);
+                        // accessSpecifier = null;
+                    }
 
+                    for (int i = 0; i < ctx.getChildCount(); i++) {
+                        if (ctx.getChild(i) instanceof CPP14Parser.DeclspecifierseqContext) {
+                            memberVariable.setType(new Type(ctx.getChild(i).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getText()));
+                        }
+                        if (ctx.getChild(i) instanceof CPP14Parser.MemberdeclaratorlistContext) {
+                            memberVariable.setName(ctx.getChild(i).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getText());
+                        }
+                    }
+                    cpp.getClasses().get(cpp.getClasses().size() - 1).addMemberVariable(memberVariable);
+                }
 
-        if (accessSpecifier != null) {
-            memberVariable.setAccessSpecifier(accessSpecifier);
-           // accessSpecifier = null;
+                if (ctx.getChild(1).getChild(0).getChild(0).getChild(0).getChild(0).getChild(1) instanceof CPP14Parser.ParametersandqualifiersContext) {      //メンバ関数のとき
+                    MemberFunction memberFunction = new MemberFunction();
+                    if (accessSpecifier != null) {
+                        memberFunction.setAccessSpecifier(accessSpecifier);
+                        // accessSpecifier = null;
+                    }
+                    for (int i = 0; i < ctx.getChildCount(); i++) {
+                        if (ctx.getChild(i) instanceof CPP14Parser.DeclspecifierseqContext) {
+                            memberFunction.setType(new Type(ctx.getChild(i).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getText()));
+                        }
+                        if (ctx.getChild(i) instanceof CPP14Parser.MemberdeclaratorlistContext) {
+                            memberFunction.setName(ctx.getChild(i).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getText());
+                        }
+                    }
+                    cpp.getClasses().get(cpp.getClasses().size() - 1).addMemberFunction(memberFunction);
+                }
+
+            }
+
         }
 
-        for (int i = 0; i < ctx.getChildCount(); i++) {
-            if (ctx.getChild(i) instanceof CPP14Parser.DeclspecifierseqContext) {
-                memberVariable.setType(new Type(ctx.getChild(i).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getText()));
-            }
-            if (ctx.getChild(i) instanceof CPP14Parser.MemberdeclaratorlistContext) {
-                memberVariable.setName(ctx.getChild(i).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getChild(0).getText());
-            }
-        }
-        cpp.getClasses().get(cpp.getClasses().size()-1).addMemberVariable(memberVariable);
-    }
+    @Override
+    public void exitMemberdeclaration(CPP14Parser.MemberdeclarationContext ctx) { memberdeclarationFlag=false; }
 
     @Override
     public void enterFunctiondefinition(CPP14Parser.FunctiondefinitionContext ctx) {
-        functiondefinitionFlag=true;
+      //  functiondefinitionFlag=true;
         MemberFunction memberFunction = new MemberFunction();
 
         if (accessSpecifier != null) {
@@ -88,12 +114,12 @@ public class CppEvalListener extends CPP14BaseListener {
 
     }
 
-    @Override public void exitFunctiondefinition(CPP14Parser.FunctiondefinitionContext ctx) { functiondefinitionFlag=true; }
+   // @Override public void exitFunctiondefinition(CPP14Parser.FunctiondefinitionContext ctx) { functiondefinitionFlag=true; }     //ここfalseじゃね？
 
     @Override
     public void enterParameterdeclaration(CPP14Parser.ParameterdeclarationContext ctx) {
 //        if (! (ctx.getParent().getParent().getParent().getParent().getParent().getParent().getParent() instanceof CPP14Parser.FunctiondefinitionContext)) return;
-        if (functiondefinitionFlag == true) {
+        if (memberdeclarationFlag == true) {
             Argument argument = new Argument();
 
             if (ctx.getChild(0).getChild(0).getChild(0).getChild(0).getChild(0) instanceof CPP14Parser.SimpletypespecifierContext) {

--- a/src/main/java/io/github/morichan/retuss/listener/CppLanguage.java
+++ b/src/main/java/io/github/morichan/retuss/listener/CppLanguage.java
@@ -13,36 +13,19 @@ public class CppLanguage {
 
     private Cpp cpp;
 
-    private String className;
-    private String extendedClassName;
+//    private String className;
+//    private String extendedClassName;
 
     public void parseForClassDiagram(String code) {
         walk(code);
-        className = searchClassName();
-        extendedClassName = searchExtendedClassName();
         cpp = cppEvalListener.getCpp();
     }
 
-    private String searchClassName() {
-        String name = "";
-        return name;
+
+    public Cpp getCpp() {
+        return cpp;
     }
 
-    /**
-     * <p> 継承先クラス名を探索する。 </p>
-     *
-     * <p>
-     * 事前に{@link #walk(String)}を実行する必要がある。
-     * 走査後、予約語 "extends" 以降 "implements" または "{" 以前の文字列を抽出する。
-     * その際に、実際に文法的に使えるかどうかはともかく、間のスペースやアノテーション、カギ括弧 "[]" は無視する。
-     * </p>
-     *
-     * @return 予約語 "extends" 以降 "implements" または "{" 以前の文字列（間のスペース、アノテーションおよびカギ括弧 "[]" は無視）
-     */
-    private String searchExtendedClassName() {
-        String name = "";
-        return name;
-    }
 
 
     private void walk(String code) {

--- a/src/main/java/io/github/morichan/retuss/translator/Translator.java
+++ b/src/main/java/io/github/morichan/retuss/translator/Translator.java
@@ -48,4 +48,18 @@ public class Translator {
 
         classDiagramPackage = umlTranslator.translate(java);
     }
+
+
+    /**
+     * <p> Cppを基にクラス図へ翻訳します </p>
+     *
+     * @param cpp cppソースコード
+     */
+    public void translate(Cpp cpp) {
+        UMLTranslator umlTranslator = new UMLTranslator();
+
+        classDiagramPackage = umlTranslator.translate(cpp);
+    }
+
+
 }

--- a/src/main/java/io/github/morichan/retuss/translator/UMLTranslator.java
+++ b/src/main/java/io/github/morichan/retuss/translator/UMLTranslator.java
@@ -146,8 +146,15 @@ public class UMLTranslator {
         Class classClass = new Class(cppClass.getName());
 
         for (MemberVariable memberVariable : cppClass.getMemberVariables()) {
+
             Attribute attribute = new Attribute(new Name(memberVariable.getName()));
-            attribute.setType(new Type(memberVariable.getType().toString()));
+            if(memberVariable.getType().toString().equals( "string")) {
+           // if(memberVariable.getType().equals(new io.github.morichan.retuss.language.cpp.Type("string"))) {
+                attribute.setType(new Type("String"));
+            }else {
+                attribute.setType(new Type(memberVariable.getType().toString()));
+            }
+    //        attribute.setType(new Type(memberVariable.getType().toString()));
             attribute.setVisibility(convert(memberVariable.getAccessSpecifier()));
             if (memberVariable.getValue() != null) {
                 attribute.setDefaultValue(new DefaultValue(new OneIdentifier(memberVariable.getValue().toString())));

--- a/src/main/java/io/github/morichan/retuss/translator/UMLTranslator.java
+++ b/src/main/java/io/github/morichan/retuss/translator/UMLTranslator.java
@@ -12,6 +12,12 @@ import io.github.morichan.retuss.language.java.*;
 import io.github.morichan.retuss.language.uml.Class;
 import io.github.morichan.retuss.language.uml.Package;
 
+import  io.github.morichan.retuss.language.cpp.Cpp;
+import  io.github.morichan.retuss.language.cpp.MemberVariable;
+import  io.github.morichan.retuss.language.cpp.MemberFunction;
+import  io.github.morichan.retuss.language.cpp.AccessSpecifier;
+
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -39,6 +45,9 @@ public class UMLTranslator {
 
         return classPackage;
     }
+
+
+
 
     private Class createClass(io.github.morichan.retuss.language.java.Class javaClass) {
         Class classClass = new Class(javaClass.getName());
@@ -100,4 +109,107 @@ public class UMLTranslator {
             }
         }
     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    /**
+     * <p> Cppからクラス図のパッケージに翻訳します </p>
+     *
+     * @param  cpp
+     * @return クラス図のパッケージ
+     */
+    public Package translate(Cpp cpp) {
+        classPackage = new Package();
+
+        for (io.github.morichan.retuss.language.cpp.Class cppClass : cpp.getClasses()) {
+            classPackage.addClass(createClass(cppClass));
+        }
+
+        searchGeneralizationClass_Cpp(cpp.getClasses());
+
+        return classPackage;
+    }
+
+    private Class createClass(io.github.morichan.retuss.language.cpp.Class cppClass) {
+        Class classClass = new Class(cppClass.getName());
+
+        for (MemberVariable memberVariable : cppClass.getMemberVariables()) {
+            Attribute attribute = new Attribute(new Name(memberVariable.getName()));
+            attribute.setType(new Type(memberVariable.getType().toString()));
+            attribute.setVisibility(convert(memberVariable.getAccessSpecifier()));
+            if (memberVariable.getValue() != null) {
+                attribute.setDefaultValue(new DefaultValue(new OneIdentifier(memberVariable.getValue().toString())));
+            }
+            classClass.addAttribute(attribute);
+        }
+        for (MemberFunction memberFunction : cppClass.getMemberFunctions()) {
+            Operation operation = new Operation(new Name(memberFunction.getName()));
+            operation.setReturnType(new Type(memberFunction.getType().toString()));
+            operation.setVisibility(convert(memberFunction.getAccessSpecifier()));
+            for (io.github.morichan.retuss.language.cpp.Argument argument : memberFunction.getArguments()) {
+                Parameter parameter = new Parameter(new Name(argument.getName()));
+                parameter.setType(new Type(argument.getType().toString()));
+                operation.addParameter(parameter);
+            }
+            classClass.addOperation(operation);
+        }
+
+        return classClass;
+    }
+
+
+    private Visibility convert(AccessSpecifier accessSpecifier) {
+        if (accessSpecifier == AccessSpecifier.Public) {
+            return Visibility.Public;
+        } else if (accessSpecifier == AccessSpecifier.Protected) {
+            return Visibility.Protected;
+        }
+//        else if (accessSpecifier == AccessSpecifier.Package) {
+//            return Visibility.Package;
+//        }
+        else {
+            return Visibility.Private;
+        }
+    }
+
+    /**
+     * <p> 汎化関係のクラスをディープコピーします </p>
+     *
+     * <p>
+     *     手法について詳しくは {@link CppTranslator#searchGeneralizationClass(List)} を参照してください。
+     * </p>
+     *
+     * @param cppClasses Cppのクラスリスト
+     */
+    private void searchGeneralizationClass_Cpp(List<io.github.morichan.retuss.language.cpp.Class> cppClasses) {
+        for (int i = 0; i < cppClasses.size(); i++) {
+            if (cppClasses.get(i).getExtendsClassName() != null) {
+                int finalI = i;
+                List<io.github.morichan.retuss.language.uml.Class> oneExtendsClass =
+                        classPackage.getClasses().stream().filter(
+                                cp -> cp.getName().equals(cppClasses.get(finalI).getExtendsClassName())
+                        ).collect(Collectors.toList());
+                classPackage.getClasses().get(finalI).setGeneralizationClass(oneExtendsClass.get(0));
+            }
+        }
+    }
+
+
+
+
+
+
+
 }

--- a/src/main/java/io/github/morichan/retuss/window/CodeController.java
+++ b/src/main/java/io/github/morichan/retuss/window/CodeController.java
@@ -105,7 +105,9 @@ public class CodeController {
             convertCodeToUml(Language.Cpp);
         });
 
-        if (cpp.getClasses().size() > 0 && !cpp.getClasses().get(0).toString().equals(codeArea.getText())) codeArea.replaceText(cpp.getClasses().get(0).toString());
+       // if (cpp.getClasses().size() > 0 && !cpp.getClasses().get(0).toString().equals(codeArea.getText())) codeArea.replaceText(cpp.getClasses().get(0).toString());
+        if (cppClass != null) codeArea.replaceText(cppClass.toString());
+
 
         AnchorPane codeAnchor = new AnchorPane(codeArea);
         AnchorPane.setBottomAnchor(codeArea, 0.0);
@@ -149,9 +151,9 @@ public class CodeController {
                 umlPackage = translator.getPackage();
 
                 mainController.writeUmlForCode(umlPackage);
-            } else { // if (language == Language.Cpp) {
+            } else  if (language == Language.Cpp) {
                 cppLanguage.parseForClassDiagram(getCode(1,0));
-                // translator.translate(cppLanguage.getCpp());
+                 translator.translate(cppLanguage.getCpp());
 
                 umlPackage = translator.getPackage();
 

--- a/src/test/java/io/github/morichan/retuss/listener/CppEvalListenerTest.java
+++ b/src/test/java/io/github/morichan/retuss/listener/CppEvalListenerTest.java
@@ -52,7 +52,7 @@ class CppEvalListenerTest {
         assertThat(actual).isEqualTo(expected);
     }
     @Test
-    void 一番最後のメンバ変数を返す() {
+    void メンバ変数を１つ返す() {
         init("class cppClassName {private: int x;};");
         String expected = "x";
 


### PR DESCRIPTION
UMLTranslatorのc++からumlに変更するときの'string'の処理の分割。

cppパッケージの中身の変更はstd::stringとするための変更だと思われる。あと、#include<string>の機能もまだ残っている。

cppEvailLisnerの変更はメソッド探索の変更と型名がstringの時に別の探索を追加